### PR TITLE
Fix multiple attaching window load handler

### DIFF
--- a/jquery.prettyembed.js
+++ b/jquery.prettyembed.js
@@ -200,13 +200,6 @@
 				$newDOMElement.html( $(this).html() );
 				$(this).remove();
 			}
-
-			// if mobile, go straight to iframe
-			if (mobile) {
-				$(window).on('load', function() {
-					$('.pretty-embed').trigger('click');
-				});
-			}
 		});
 
 
@@ -218,7 +211,12 @@
 			clickEventRunner( $(this) );
 		});
 
-
+		// if mobile, go straight to iframe
+		if (mobile) {
+			$(window).on('load', function() {
+				$('.pretty-embed').trigger('click');
+			});
+		}
 
 		/**
 		 * Function: clickEventRunner(obj)


### PR DESCRIPTION
Move the code to out of `each` :

```
if (mobile) {
    $(window).on('load', function() {
        $('.pretty-embed').trigger('click');
    });
}
```
